### PR TITLE
Dark Mode - Colors in XCAssets Catalog

### DIFF
--- a/Auto Layout/BottomSeparatorCell.swift
+++ b/Auto Layout/BottomSeparatorCell.swift
@@ -15,7 +15,7 @@ class BottomSeparatorCell: UICollectionViewCell, Reusable {
 
     let separator = UIView()
     contentView.addSubview(separator)
-    separator.backgroundColor = .separator
+    separator.backgroundColor = .timesGray60
     separator.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
       separator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),

--- a/Auto Layout/CollectionViewController.swift
+++ b/Auto Layout/CollectionViewController.swift
@@ -27,8 +27,8 @@ final class CollectionViewController: UICollectionViewController, UICollectionVi
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .systemBackground
-    collectionView.backgroundColor = .systemBackground
+    view.backgroundColor = .timesWhite
+    collectionView.backgroundColor = .timesWhite
     collectionView.dataSource = dataSource
     collectionView.delegate = self
     collectionView.register(cell: WrapperCell<HeadlineSummaryView>.self)

--- a/Auto Layout/FooterView.swift
+++ b/Auto Layout/FooterView.swift
@@ -19,7 +19,7 @@ final class FooterView: UIView {
       string: displayDate,
       attributes: [
         .font: UIFont.systemFont(ofSize: 12),
-        .foregroundColor: UIColor.gray
+        .foregroundColor: UIColor.timesGray50
       ])
     return label
   }()

--- a/Auto Layout/HeadlineSummaryView.swift
+++ b/Auto Layout/HeadlineSummaryView.swift
@@ -25,7 +25,7 @@ final class HeadlineSummaryView: UIView {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    backgroundColor = .white
+    backgroundColor = .timesWhite
 
     let stackView = UIStackView(arrangedSubviews: [headlineView, summaryView, footerView])
     stackView.axis = .vertical
@@ -48,7 +48,7 @@ final class HeadlineSummaryView: UIView {
       string: headline,
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ]
     )
 
@@ -56,7 +56,7 @@ final class HeadlineSummaryView: UIView {
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ]
     )
   }

--- a/Auto Layout/LargeImageView.swift
+++ b/Auto Layout/LargeImageView.swift
@@ -75,14 +75,14 @@ final class LargeImageView: UIView {
       string: headline,
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ])
 
     summaryLabel.attributedText = NSAttributedString(
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ])
     imageView.image = UIImage(named: crop.imageFilename)
     imageAspectConstraint.isActive = false
@@ -96,7 +96,7 @@ final class LargeImageView: UIView {
       string: credit,
       attributes: [
         .font: UIFont.systemFont(ofSize: 9),
-        .foregroundColor: UIColor.lightGray
+        .foregroundColor: UIColor.timesGray30
       ])
     creditLabel.isHidden = credit.isEmpty
 
@@ -104,7 +104,7 @@ final class LargeImageView: UIView {
       string: kicker,
       attributes: [
         .font: UIFont.systemFont(ofSize: 12),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ])
     kickerLabel.isHidden = kicker.isEmpty
 

--- a/Auto Layout/SuperMegaiPadView.swift
+++ b/Auto Layout/SuperMegaiPadView.swift
@@ -13,7 +13,7 @@ final class SuperMegaiPadView: UIView {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
-    backgroundColor = .white
+    backgroundColor = .timesWhite
 
     let headline = ContentGenerator.thisManyWords(2...8)
     let summary = ContentGenerator.thisManyWords(20...40)

--- a/Auto Layout/ThumbnailView.swift
+++ b/Auto Layout/ThumbnailView.swift
@@ -29,7 +29,7 @@ final class ThumbnailView: UIView {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    backgroundColor = .white
+    backgroundColor = .timesWhite
 
     stackView.addArrangedSubviews([textView, footerView])
     stackView.axis = .vertical
@@ -75,7 +75,7 @@ final class ThumbnailView: UIView {
       string: headline + "\n",
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ]
     )
 
@@ -83,7 +83,7 @@ final class ThumbnailView: UIView {
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ]
     )
 

--- a/Auto Layout/WebView.swift
+++ b/Auto Layout/WebView.swift
@@ -19,7 +19,7 @@ final class WebView: UIView {
       attributes: [
         .paragraphStyle: paragraphStyle,
         .font: UIFont.systemFont(ofSize: 9.0),
-        .foregroundColor: UIColor.lightGray
+        .foregroundColor: UIColor.timesGray60
       ])
   }
 

--- a/Hybrid/HybridCollectionView/HybridCollectionViewController.swift
+++ b/Hybrid/HybridCollectionView/HybridCollectionViewController.swift
@@ -20,8 +20,8 @@ final class HybridCollectionViewController: UICollectionViewController, UICollec
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .systemBackground
-    collectionView.backgroundColor = .systemBackground
+    view.backgroundColor = .timesWhite
+    collectionView.backgroundColor = .timesWhite
     collectionView.dataSource = dataSource
     collectionView.delegate = self
     collectionView.register(cell: TextureWrapperCell<HeadlineSummaryCellNode>.self)

--- a/Sample.xcodeproj/project.pbxproj
+++ b/Sample.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		050E7C7419D22E19004363C2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050E7C7319D22E19004363C2 /* AppDelegate.swift */; };
 		050E7C7619D22E19004363C2 /* TextureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050E7C7519D22E19004363C2 /* TextureViewController.swift */; };
+		1DE4EF9F2554BABF00791B8D /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DE4EF9E2554BABF00791B8D /* Colors.xcassets */; };
+		1DE4EFA42554C9D400791B8D /* UIColor+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE4EFA32554C9D400791B8D /* UIColor+Colors.swift */; };
 		2A3038B01DC8F02C00228931 /* miles.png in Resources */ = {isa = PBXBuildFile; fileRef = 2A3038AF1DC8F02C00228931 /* miles.png */; };
 		2A3038B41DC8F7DD00228931 /* RRFPSBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A3038B31DC8F7DD00228931 /* RRFPSBar.m */; };
 		2A3038B61DC90F6900228931 /* FooterNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3038B51DC90F6900228931 /* FooterNode.swift */; };
@@ -66,6 +68,8 @@
 		050E7C6E19D22E19004363C2 /* Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		050E7C7319D22E19004363C2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		050E7C7519D22E19004363C2 /* TextureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextureViewController.swift; sourceTree = "<group>"; };
+		1DE4EF9E2554BABF00791B8D /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		1DE4EFA32554C9D400791B8D /* UIColor+Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Colors.swift"; sourceTree = "<group>"; };
 		2A3038AF1DC8F02C00228931 /* miles.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = miles.png; sourceTree = "<group>"; };
 		2A3038B11DC8F7DC00228931 /* Sample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Sample-Bridging-Header.h"; sourceTree = "<group>"; };
 		2A3038B21DC8F7DD00228931 /* RRFPSBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RRFPSBar.h; sourceTree = "<group>"; };
@@ -175,6 +179,7 @@
 				050E7C7319D22E19004363C2 /* AppDelegate.swift */,
 				9436AAD41DBA78170029B9B2 /* Crop.swift */,
 				CDA802F9250AB27B003C27D3 /* Section.swift */,
+				1DE4EFA32554C9D400791B8D /* UIColor+Colors.swift */,
 				2A3038B21DC8F7DD00228931 /* RRFPSBar.h */,
 				2A3038B31DC8F7DD00228931 /* RRFPSBar.m */,
 				CD55E8152509460E00F86A08 /* Supporting Files */,
@@ -211,6 +216,7 @@
 				9436AAD21DB9A0D80029B9B2 /* coltrane.jpg */,
 				2A3038AF1DC8F02C00228931 /* miles.png */,
 				2A3038B71DC9119200228931 /* Media.xcassets */,
+				1DE4EF9E2554BABF00791B8D /* Colors.xcassets */,
 				CD55E8162509460E00F86A08 /* Info.plist */,
 				CD55E8182509465900F86A08 /* Launch Screen.storyboard */,
 			);
@@ -404,6 +410,7 @@
 				CD55E8192509465900F86A08 /* Launch Screen.storyboard in Resources */,
 				9436AAD31DB9A0D80029B9B2 /* coltrane.jpg in Resources */,
 				9436AACF1DB835C40029B9B2 /* thumbnail.jpg in Resources */,
+				1DE4EF9F2554BABF00791B8D /* Colors.xcassets in Resources */,
 				2A3038B81DC9119200228931 /* Media.xcassets in Resources */,
 				2A3038B01DC8F02C00228931 /* miles.png in Resources */,
 			);
@@ -494,6 +501,7 @@
 				CDEF69062502867C006082AB /* HeadlineSummaryView.swift in Sources */,
 				9436AAD11DB9A0290029B9B2 /* LargeImageCellNode.swift in Sources */,
 				D53BDE7D25015FB5001FB387 /* ContentGenerator.swift in Sources */,
+				1DE4EFA42554C9D400791B8D /* UIColor+Colors.swift in Sources */,
 				9436AACB1DB81B6C0029B9B2 /* HeadlineSummaryCellNode.swift in Sources */,
 				CDEF690425028637006082AB /* ThumbnailView.swift in Sources */,
 				CDA802FA250AB27B003C27D3 /* Section.swift in Sources */,

--- a/Sample/AppDelegate.swift
+++ b/Sample/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       RRFPSBar.sharedInstance().isHidden = false
     }
     let window = UIWindow(frame: UIScreen.main.bounds)
-    window.backgroundColor = UIColor.white
+    window.backgroundColor = UIColor.timesWhite
     window.rootViewController = tabBarController
     window.makeKeyAndVisible()
     self.window = window

--- a/Sample/Supporting Files/Colors.xcassets/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Semantic Colors/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Semantic Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Semantic Colors/breakingRed.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Semantic Colors/breakingRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1B",
+          "green" : "0x02",
+          "red" : "0xD0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x1E",
+          "red" : "0xD3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Semantic Colors/developingOrange.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Semantic Colors/developingOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x51",
+          "green" : "0x87",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Semantic Colors/messagingBlue.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Semantic Colors/messagingBlue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xB4",
+          "red" : "0x0B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Semantic Colors/opinionGrey.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Semantic Colors/opinionGrey.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9D",
+          "green" : "0x9D",
+          "red" : "0xA1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesBlack.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray10.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray10.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF7",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray20.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray20.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xF3",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray30.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray30.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0x66"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray40.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray40.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0x99",
+          "red" : "0x99"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE2",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray50.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCC",
+          "green" : "0xCC",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCC",
+          "green" : "0xCC",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray60.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray60.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xE2",
+          "red" : "0xE2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x99",
+          "green" : "0x99",
+          "red" : "0x99"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray70.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray70.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x66",
+          "red" : "0x66"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray80.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray80.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF3",
+          "green" : "0xF3",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray90.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesGray90.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF7",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/Supporting Files/Colors.xcassets/Times Colors/timesWhite.colorset/Contents.json
+++ b/Sample/Supporting Files/Colors.xcassets/Times Colors/timesWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample/UIColor+Colors.swift
+++ b/Sample/UIColor+Colors.swift
@@ -1,0 +1,71 @@
+//
+//  UIColor+Colors.swift
+//  Sample
+//
+//  Created by Murray, Mark on 11/5/20.
+//  Copyright © 2020 The New York Times. All rights reserved.
+//
+
+import Foundation
+
+extension UIColor {
+  static var breakingRed: UIColor {
+    UIColor(named: "breakingRed")!
+  }
+
+  static var developingOrange: UIColor {
+    UIColor(named: "developingOrange")!
+  }
+
+  static var messagingBlue: UIColor {
+    UIColor(named: "messagingBlue")!
+  }
+
+  static var opinionGrey: UIColor {
+    UIColor(named: "opinionGrey")!
+  }
+
+  static var timesBlack: UIColor {
+    UIColor(named: "timesBlack")!
+  }
+
+  static var timesGray10: UIColor {
+    UIColor(named: "timesGray10")!
+  }
+
+  static var timesGray20: UIColor {
+    UIColor(named: "timesGray20")!
+  }
+
+  static var timesGray30: UIColor {
+    UIColor(named: "timesGray30")!
+  }
+
+  static var timesGray40: UIColor {
+    UIColor(named: "timesGray40")!
+  }
+
+  static var timesGray50: UIColor {
+    UIColor(named: "timesGray50")!
+  }
+
+  static var timesGray60: UIColor {
+    UIColor(named: "timesGray60")!
+  }
+
+  static var timesGray70: UIColor {
+    UIColor(named: "timesGray70")!
+  }
+
+  static var timesGray80: UIColor {
+    UIColor(named: "timesGray80")!
+  }
+
+  static var timesGray90: UIColor {
+    UIColor(named: "timesGray90")!
+  }
+
+  static var timesWhite: UIColor {
+    UIColor(named: "timesWhite")!
+  }
+}

--- a/Texture/FooterNode.swift
+++ b/Texture/FooterNode.swift
@@ -25,7 +25,7 @@ final class FooterNode: ASDisplayNode {
       string: displayDate,
       attributes: [
         .font: UIFont.systemFont(ofSize: 12),
-        .foregroundColor: UIColor.gray
+        .foregroundColor: UIColor.timesGray50
       ])
 
     shareButtonNode.setImage(UIImage(named: "NYTShareIcon"), for: .normal)

--- a/Texture/HeadlineSummaryCellNode.swift
+++ b/Texture/HeadlineSummaryCellNode.swift
@@ -21,14 +21,14 @@ final class HeadlineSummaryCellNode: ASCellNode {
       string: headline,
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ])
 
     summaryNode.attributedText = NSAttributedString(
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ])
 
     addSubnode(headlineNode)

--- a/Texture/LargeImageCellNode.swift
+++ b/Texture/LargeImageCellNode.swift
@@ -34,7 +34,7 @@ final class LargeImageCellNode: ASCellNode {
         string: credit,
         attributes: [
           .font: UIFont.systemFont(ofSize: 9),
-          .foregroundColor: UIColor.lightGray
+          .foregroundColor: UIColor.timesGray30
         ])
     }
 
@@ -43,7 +43,7 @@ final class LargeImageCellNode: ASCellNode {
         string: kicker,
         attributes: [
           .font: UIFont.systemFont(ofSize: 12),
-          .foregroundColor: UIColor.black
+          .foregroundColor: UIColor.timesBlack
         ])
     }
 
@@ -51,14 +51,14 @@ final class LargeImageCellNode: ASCellNode {
       string: headline,
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ])
     
     summaryNode.attributedText = NSAttributedString(
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ])
 
     addSubnode(imageNode)

--- a/Texture/ThumbnailCellNode.swift
+++ b/Texture/ThumbnailCellNode.swift
@@ -22,7 +22,7 @@ final class ThumbnailCellNode: ASCellNode {
       string: "\(headline)\n",
       attributes: [
         .font: UIFont.boldSystemFont(ofSize: 18),
-        .foregroundColor: UIColor.black
+        .foregroundColor: UIColor.timesBlack
       ])
     let spacerAttributedString = NSAttributedString(
       string: "\n",
@@ -33,7 +33,7 @@ final class ThumbnailCellNode: ASCellNode {
       string: summary,
       attributes: [
         .font: UIFont.systemFont(ofSize: 14),
-        .foregroundColor: UIColor.darkGray
+        .foregroundColor: UIColor.timesGray10
       ])
     
     let attributedString = NSMutableAttributedString()

--- a/Texture/WebCellNode.swift
+++ b/Texture/WebCellNode.swift
@@ -30,7 +30,7 @@ final class WebCellNode: ASCellNode {
       attributes: [
         .font: UIFont.systemFont(ofSize: 9.0),
         .paragraphStyle: paragraphStyle,
-        .foregroundColor: UIColor.lightGray
+        .foregroundColor: UIColor.timesGray60
       ])
     
     addSubnode(disclaimerNode)


### PR DESCRIPTION
This is a competing approach with PR #1 that instead defines the dynamic colors in a new `Colors.xcassets` catalog. There 11 greyscale colors and 4 semantic color defines, not all of which are used but I wanted to give a complete example.

The asset catalog colors are referenced in code via `UIColor(named: String)` which is clunky. I've manually added an extension that defines all of these as `static var`s, that can easily be generated with a tool like SwiftGen or R.Swift.

I've then gone into the views and selected similar colors like I did in PR #1. The result is equivalent of course, it's just a different method of getting.